### PR TITLE
Add missing UIKit include

### DIFF
--- a/src/utils.m
+++ b/src/utils.m
@@ -1,6 +1,7 @@
 #import "utils.h"
 #import <Foundation/Foundation.h>
 #import <sys/sysctl.h>
+#import <UIKit/UIKit.h>
 
 NSString *fetchSysctlString(const char *name) {
     char buffer[256];


### PR DESCRIPTION
When cloning the repo and running make, for some reason the compiler will report errors about UIDevice and etc stuff from UIKit not found. I've added the missing include in utils.m and everything started to work correctly.